### PR TITLE
Add stroke-width for mini profiles in StatusIndicater.css

### DIFF
--- a/Module/StatusIndicater.css
+++ b/Module/StatusIndicater.css
@@ -444,6 +444,8 @@
     x: -50% !important;
     y: -50% !important;
     transform: translate(50%, 50%) !important;
+    /* Make the stroke much thinner for mini profiles */
+    stroke-width: 1px !important;
 }
 
 /* ============================================


### PR DESCRIPTION
Updated the stroke-width to 1px for mini profiles to enhance visual clarity and maintain consistency with the overall design.